### PR TITLE
A604204973640971 swiftsure procedure accreditation

### DIFF
--- a/openprocurement/auctions/swiftsure/models.py
+++ b/openprocurement/auctions/swiftsure/models.py
@@ -125,6 +125,9 @@ class SwiftsureAuction(BaseAuction):
     minNumberOfQualifiedBids = IntType(choices=[1], default=1)
     transfer_token = StringType()
 
+    create_accreditation = 3
+    edit_accreditation = 4
+
     def __acl__(self):
         return [
             (Allow, '{}_{}'.format(self.owner, self.owner_token), 'edit_auction'),

--- a/openprocurement/auctions/swiftsure/tests/auth.ini
+++ b/openprocurement/auctions/swiftsure/tests/auth.ini
@@ -11,7 +11,7 @@ administrator = administrator
 chrisr = chrisr
 
 [brokers]
-broker = broker
+broker = broker,124
 broker05 = broker05
 broker1 = broker1,1
 broker2 = broker2,2
@@ -29,3 +29,6 @@ test = token
 
 [convoy]
 convoy = convoy
+
+[concierge]
+concierge = concierge,3

--- a/openprocurement/auctions/swiftsure/views/complaint.py
+++ b/openprocurement/auctions/swiftsure/views/complaint.py
@@ -39,7 +39,7 @@ class AuctionComplaintResource(AuctionComplaintResource):
         else:
             complaint.status = 'draft'
         complaint.complaintID = '{}.{}{}'.format(auction.auctionID, self.server_id, sum([len(i.complaints) for i in auction.awards], len(auction.complaints)) + 1)
-        acc = set_ownership(complaint, self.request)
+        set_ownership(complaint, self.request)
         auction.complaints.append(complaint)
         if save_auction(self.request):
             self.LOGGER.info('Created auction complaint {}'.format(complaint.id),
@@ -47,7 +47,12 @@ class AuctionComplaintResource(AuctionComplaintResource):
             self.request.response.status = 201
             route = self.request.matched_route.name.replace("collection_", "")
             self.request.response.headers['Location'] = self.request.current_route_url(_route_name=route, complaint_id=complaint.id, _query={})
-            return {'data': complaint.serialize(auction.status), 'access': acc}
+            return {
+                'data': complaint.serialize(auction.status),
+                'access': {
+                    'token': complaint.owner_token
+                }
+            }
 
     @json_view(content_type="application/json", validators=(validate_patch_complaint_data,), permission='edit_complaint')
     def patch(self):


### PR DESCRIPTION
### Depends on:

- https://github.com/openprocurement/openprocurement.auctions.core/pull/115

Add specific accreditation levels for auction procedure
Add level 3 for auction procedure creation, which available only for concierge
Add level 4 for auction procedure editing for actual auction owner

* Remove transfer_token support from complaint object
* Update auth.ini
* Update tests due to new levels of accreditation