### PR TITLE
Update tests due to changes in edit_active.tendering role

### DIFF
--- a/openprocurement/auctions/swiftsure/tests/blanks/tender_blanks.py
+++ b/openprocurement/auctions/swiftsure/tests/blanks/tender_blanks.py
@@ -3,7 +3,6 @@ from copy import deepcopy
 from datetime import timedelta, time
 from iso8601 import parse_date
 
-from openprocurement.auctions.core.constants import DGF_ELIGIBILITY_CRITERIA
 from openprocurement.auctions.core.tests.base import JSON_RENDERER_ERROR
 from openprocurement.auctions.core.utils import get_now, SANDBOX_MODE, TZ
 
@@ -27,15 +26,12 @@ def create_role(self):
 
 
 def edit_role(self):
-    fields = set([
-        'features', 'hasEnquiries', 'description', 'description_en', 'description_ru',
-        'title', 'title_en', 'title_ru', 'tenderAttempts',
-        'merchandisingObject',
-    ])
-    if SANDBOX_MODE:
-        fields.add('procurementMethodDetails')
-    self.assertEqual(set(self.auction._fields) - self.auction._options.roles['edit_active.tendering'].fields, fields)
-
+    fields = set([])
+    role = self.auction._options.roles['edit_active.tendering']
+    if role.function.__name__ == 'blacklist':
+        self.assertEqual(set(self.auction._fields) - role.fields, fields)
+    else:
+        self.assertEqual(set(self.auction._fields).intersection(role.fields), fields)
 # AuctionResourceTest
 
 

--- a/openprocurement/auctions/swiftsure/tests/transferring.py
+++ b/openprocurement/auctions/swiftsure/tests/transferring.py
@@ -17,11 +17,11 @@ class AuctionOwnershipChangeResourceTest(BaseAuctionWebTest,
     first_owner = 'broker3'
     second_owner = 'broker3'
     concierge = 'concierge'
-    test_owner = 'broker1t'
+    test_owner = 'broker3t'
     invalid_owner = 'broker1'
     initial_auth = ('Basic', (first_owner, ''))
 
-    test_mode_test = None
+    test_new_owner_can_change = None  # swiftsure auction can not be changed during enquiryPeriod
     test_create_auction_by_concierge = snitch(create_auction_by_concierge)
 
     def setUp(self):


### PR DESCRIPTION
### Depends on:

- https://github.com/openprocurement/openprocurement.auctions.core/pull/134